### PR TITLE
Spawn cap

### DIFF
--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -9,7 +9,7 @@ public class EnemyBase : MonoBehaviour, IDamageable
     public GameObject PlayerBaseObject;
     float spawnHeight = 0f; // Height from which the enemy will be spawned
     // public Vector2 newSize = new Vector2(1,1);
-    float nextSpwanTime = 0f;
+    float nextSpawnTime = 0f;
 
     void Start()
     {
@@ -25,8 +25,8 @@ public class EnemyBase : MonoBehaviour, IDamageable
     
     void Update()
     {
-        nextSpwanTime -= Time.deltaTime;
-        if (nextSpwanTime <= 0)
+        nextSpawnTime -= Time.deltaTime;
+        if (nextSpawnTime <= 0)
         {
             if (GameManager.Instance.WithinEnemySpawnCap())
             {
@@ -65,7 +65,7 @@ public class EnemyBase : MonoBehaviour, IDamageable
 
     private void resetNextSpawnTime()
     {
-        nextSpwanTime = Random.Range(1f, 5f);
+        nextSpawnTime = Random.Range(1f, 5f);
     }
 
     public void TakeDamage(float damageAmount)

--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -28,9 +28,12 @@ public class EnemyBase : MonoBehaviour, IDamageable
         nextSpwanTime -= Time.deltaTime;
         if (nextSpwanTime <= 0)
         {
-            //just spwans the first one for now
-            Vector3 spawnPosition = new Vector3(transform.position.x, spawnHeight, transform.position.z);
-            Instantiate(enemyPrefabs[0], spawnPosition, Quaternion.identity);
+            if (GameManager.Instance.WithinEnemySpawnCap())
+            {
+                //just spwans the first one for now
+                Vector3 spawnPosition = new Vector3(transform.position.x, spawnHeight, transform.position.z);
+                Instantiate(enemyPrefabs[0], spawnPosition, Quaternion.identity);
+            }
 
             resetNextSpawnTime();
         }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -9,7 +9,7 @@ public class GameManager : MonoBehaviour
     public int LevelNumber = 1;
 
     /// <summary>
-    /// Limit for the size of team enemy (including enemy bases)
+    /// Limit for the number of enemies
     /// </summary>
     public int EnemySpawnCap = 3;
 
@@ -216,6 +216,6 @@ public class GameManager : MonoBehaviour
     /// </summary>
     public bool WithinEnemySpawnCap()
     {
-        return TeamEnemy.Count < EnemySpawnCap;
+        return (TeamEnemy.Count - EnemyBases.Count) < EnemySpawnCap;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -9,6 +9,11 @@ public class GameManager : MonoBehaviour
     public int LevelNumber = 1;
 
     /// <summary>
+    /// Limit for the size of team enemy (including enemy bases)
+    /// </summary>
+    public int EnemySpawnCap = 3;
+
+    /// <summary>
     /// All player bases currently on the map
     /// </summary>
     private HashSet<PlayerBase> PlayerBases;
@@ -204,5 +209,13 @@ public class GameManager : MonoBehaviour
         // animals never die so this method is probably unnecessary
         TeamPlayer.Remove(a.transform);
         Animals.Remove(a);
+    }
+
+    /// <summary>
+    /// returns whether more enemies can be spawned without hitting the enemy spawn cap
+    /// </summary>
+    public bool WithinEnemySpawnCap()
+    {
+        return TeamEnemy.Count < EnemySpawnCap;
     }
 }


### PR DESCRIPTION
Added spawn cap limit to enemies
This limit is specified as a field in GameManager

-details-
If the enemy limit is reached, when the spawn time is reached, the enemy will not be spawned, but the spawn timer will be reset. This choice avoids artificial behavior where a new enemy spawns the instant another one falls.
The enemy count is inferred by the size of team enemy minus the number of bases. Because of this, significant changes to TeamEnemy would affect the behavior of the enemy spawn cap.